### PR TITLE
Update app.yaml

### DIFF
--- a/src/ut_anagramma/app.yaml
+++ b/src/ut_anagramma/app.yaml
@@ -5,3 +5,10 @@ handlers:
   script: auto
   secure: always
   redirect_http_response_code: 301
+automatic_scaling:
+  target_cpu_utilization: 0.85
+  min_instances: 1
+  max_instances: 3
+  min_pending_latency: 30ms
+  max_pending_latency: automatic
+  max_concurrent_requests: 50


### PR DESCRIPTION
If you rely on Free Tier as a cost control mechanism, we recommend you consider the following alternatives to manage your App Engine costs:

    Set the max_instances setting to 1 in app.yaml, to reduce the risk of exceeding the Free Tier. This setting limits your app’s scaling ability, but isn’t a hard limit, and may allow excess usage that may increase your bill.